### PR TITLE
Add separate API-side quiz storage

### DIFF
--- a/client/screens/QuizCreate/QuizCreate.jsx
+++ b/client/screens/QuizCreate/QuizCreate.jsx
@@ -77,13 +77,14 @@ export const QuizCreate = () => {
         initialValues={{
           name: '',
           description: '',
-          questions: [{ question: '', type: '', id: uniqueId() }],
+          questions: [{ question: '', type: '', options: [], id: uniqueId() }],
           categories: [],
         }}
         onSubmit={createQuiz}
         validationSchema={quizSchema}
       >
         {({ setFieldValue, values }) => {
+          console.log(values);
           return (
             <Form className={classes.form}>
               <FastField name="name">
@@ -133,7 +134,10 @@ export const QuizCreate = () => {
               <Button
                 style={{ margin: '20px 0' }}
                 onClick={() =>
-                  setFieldValue('questions', [...values.questions, { question: '', type: '', id: uniqueId() }])
+                  setFieldValue('questions', [
+                    ...values.questions,
+                    { question: '', type: '', options: [], id: uniqueId() },
+                  ])
                 }
               >
                 Add Question

--- a/constants/quizConstants.js
+++ b/constants/quizConstants.js
@@ -9,12 +9,12 @@ export const quizSchema = yup.object().shape({
       yup.object().shape({
         question: yup.string().required(),
         type: yup.string().required(),
-        answers: yup
+        options: yup
           .array()
           .of(
             yup.object().shape({
-              answer: yup.string().required(),
-              correct: yup.boolean(),
+              option: yup.string().required(),
+              correct: yup.boolean().required(),
             }),
           )
           .required(),
@@ -35,9 +35,17 @@ export const QuizTypes = Object.freeze({
   // FillInTheBlank: 'FILLINTHEBLANK',
 });
 
+export const QuizConstants = Object.freeze({
+  True: 'TRUE',
+  False: 'FALSE',
+});
+
 export const QuizStrings = Object.freeze({
   [QuizTypes.MultipleChoice]: 'Multiple Choice',
   [QuizTypes.FillInTheBlank]: 'Fill-in-the-Blank',
   [QuizTypes.TrueFalse]: 'True or False',
   [QuizTypes.ShortAnswer]: 'Short Answer',
+
+  [QuizConstants.True]: 'True',
+  [QuizConstants.False]: 'False',
 });

--- a/server/quizzes/controller.js
+++ b/server/quizzes/controller.js
@@ -5,6 +5,7 @@ import { QUIZZES } from '../../constants';
 import { newError } from '../utils/error';
 import { StatusCode } from '../utils/http';
 import { quizSchema } from '../../constants/quizConstants';
+import { saveCreationQuiz } from './model';
 
 // get quizzes from firestore
 export const getQuizzes = async (userQuery) => {
@@ -51,23 +52,16 @@ export const getQuiz = async (id) => {
 };
 
 export const createQuiz = async (body, user) => {
-  let quiz;
+  let quizCreateBody;
   try {
-    quiz = quizSchema.validateSync(body);
+    quizCreateBody = quizSchema.validateSync(body);
   } catch (error) {
     throw newError(StatusCode.BadRequest, error.message);
   }
 
-  try {
-    const ref = db.collection(QUIZZES).doc();
-    const now = firebase.firestore.Timestamp.now();
-    await ref.set({ ...quiz, userID: user.id, id: ref.id, createdAt: now, updatedAt: now });
+  quizCreateBody.userID = user.id;
 
-    return { ...quiz, id: ref.id };
-  } catch (error) {
-    console.error(error);
-    throw newError(StatusCode.Error, error.message);
-  }
+  return saveCreationQuiz(quizCreateBody);
 };
 
 export const rateQuiz = async (userQuery) => {

--- a/server/quizzes/model.js
+++ b/server/quizzes/model.js
@@ -1,0 +1,55 @@
+import firebase from 'firebase-admin';
+import { db } from '../database/firestore';
+import { QUIZZES } from '../../constants';
+import { newError } from '../utils/error';
+import { StatusCode } from '../utils/http';
+
+export const getCreationQuiz = async (quiz) => {
+  const quizCreateBody = { ...quiz };
+  delete quizCreateBody.answers;
+
+  quizCreateBody.questions = quiz.questions.map((question) => ({
+    ...question,
+    options: question.options.map((option) => ({
+      ...option,
+      correct: !!quiz.answers[question.id][option.option],
+    })),
+  }));
+
+  return quizCreateBody;
+};
+
+export const saveCreationQuiz = async (quizCreateBody) => {
+  const ref = db.collection(QUIZZES).doc();
+  const now = firebase.firestore.Timestamp.now();
+  const payload = { ...quizCreateBody, id: ref.id, createdAt: now, updatedAt: now };
+
+  payload.answers = {};
+  quizCreateBody.questions.forEach((question) => {
+    payload.answers[question.id] = {};
+
+    question.options.forEach((option) => {
+      if (option.correct) {
+        payload.answers[question.id][option.option] = true;
+      }
+    });
+  });
+
+  payload.questions = quizCreateBody.questions.map((question) => ({
+    ...question,
+    options: question.options.map((option) => {
+      const newOption = { ...option };
+      delete newOption.correct;
+      return newOption;
+    }),
+  }));
+
+  try {
+    await ref.set(payload);
+
+    return { ...payload, id: ref.id };
+  } catch (error) {
+    console.error(error);
+    throw newError(StatusCode.Error, error.message);
+  }
+};


### PR DESCRIPTION
Restructures the persisted quiz to follow the below model:

```
{
  questions: [{
    id: int
    options: { option: string }
  }],
  answers: {
    [id]: { [option]: true }
  }
}
```